### PR TITLE
Added accessfunctions.py, test_accessfunctions.py and readme.md, changed db.py

### DIFF
--- a/backend/storage_access_layer/README.md
+++ b/backend/storage_access_layer/README.md
@@ -2,76 +2,78 @@
 
 ## Overview
 
-The **Storage Access Layer** is the component responsible for database management and access within the **Biometric Gait Dashboard** backend.  
+The Storage Access Layer is the component responsible for database management and access within the Biometric Gait Dashboard backend.  
 It defines the ORM schema, establishes the database engine connection, and exposes functions to safely query stored Swipe Event data.
 
-This layer is isolated so the rest of the project layers don't have to worry about changes in data storage format.
+This layer now automatically manages its own database sessions internally.  
+Consumers (such as Flask endpoints or backend services) can import the module directly and call its functions without manually creating or passing a session object.
+
+This design keeps the storage layer isolated so the rest of the project layers don't have to worry about changes in data storage or session management.
 
 ---
 
 ## Modules
 
-| File | Description |
-|------|--------------|
-| **`db.py`** | Defines the model (`SwipeEvent`) and utilizes the SQLAlchemy engine. |
-| **`accessfunctions.py`** | Provides functions for fetching participants, dates, directions, and events. |
+File | Description
+------|--------------
+db.py | Defines the model (SwipeEvent) and utilizes the SQLAlchemy engine, now including a session factory and context-managed helper for automatic session handling.
+accessfunctions.py | Provides functions for fetching participants, dates, directions, and events. Each function now manages its own session internally.
 
 ---
 
-## Database Model — `SwipeEvent`
+## Database Model — SwipeEvent
 
 Represents a single gait-trial event stored in the database.
 
-| Column | Type | Description |
-|---------|------|-------------|
-| `event_id` | `String` (PK) | Unique event identifier, e.g. `"001_2025-01-01_in_1_ready"`. |
-| `participant` | `Integer` | Participant |
-| `date` | `Date` | The date of the swipe event. |
-| `direction` | `String` | Direction (`"in"` or `"out"`) |
-| `event_number` | `Integer` | Event number |
-| `state` | `String` | Trial state |
-| `trial_npz_uri` | `Text` | Path to trial |
-| `trial_p100_npz_uri` | `Text` | Path to P100 |
-| `trial_grf_npz_uri` | `Text` | Path to GRF |
-| `created_at` | `TIMESTAMP` | Automatically filled on record creation using `now()` (Postgres) or `CURRENT_TIMESTAMP` (SQLite). |
+Column | Type | Description
+---------|------|-------------
+event_id | String (PK) | Unique event identifier, e.g. "001_2025-01-01_in_1_ready".
+participant | Integer | Participant ID.
+date | Date | The date of the swipe event.
+direction | String | Direction ("in" or "out").
+event_number | Integer | Event number.
+state | String | Trial state.
+trial_npz_uri | Text | Path to trial file.
+trial_p100_npz_uri | Text | Path to P100 file.
+trial_grf_npz_uri | Text | Path to GRF file.
+created_at | TIMESTAMP | Automatically filled on record creation using now() (Postgres) or CURRENT_TIMESTAMP (SQLite).
 
 ---
 
 ## Access Functions
 
-These functions (defined in `accessfunctions.py`) provide a consistent way to query the database.
+These functions (defined in accessfunctions.py) provide a consistent and session-independent way to query the database.  
+Each function internally opens and closes its own session, so no manual session handling is needed by the caller.
 
-| Function | Parameters | Returns | Description |
-|-----------|-------------|----------|--------------|
-| `getParticipants(session)` | — | `list[int]` | All participant IDs |
-| `getDates(session, participant)` | `participant: int` | `list[date]` | Dates of events |
-| `getDirections(session, participant, date)` | `participant: int`, `date: date` | `list[str]` |directions (`"in"` / `"out"`) for that date. |
-| `getEvents(session, participant, date)` | `participant: int`, `date: date` | `list[int]` | Event numbers for that participant/date. |
-| `getSwipeEventId(session, participant, date, event, direction)` | `participant, date, event, direction` | `str` or `None` | Returns the unique event ID string if it exists. |
+Function | Parameters | Returns | Description
+-----------|-------------|----------|--------------
+getParticipants() | — | list[int] | All participant IDs.
+getDates(participant) | participant: int | list[date] | Dates of events.
+getDirections(participant, date) | participant: int, date: date | list[str] | Directions ("in" / "out") for that date.
+getEvents(participant, date, direction) | participant: int, date: date, direction: str | list[int] | Event numbers for that participant/date/direction.
+getSwipeEventId(participant, date, event, direction) | participant: int, date: date, event: int, direction: str | str or None | Returns the unique event ID string if it exists.
+getBothDirectionEvents(participant, date) | participant: int, date: date | list[list[int]] | Returns both "in" and "out" direction event lists for the given participant and date. If only one direction exists, returns just that one list.
 
 ---
 
 ## Example Usage
 
-```python
-from sqlalchemy.orm import Session
-from backend.storage_access_layer.db import engine
-from backend.storage_access_layer.accessfunctions import (
-    getParticipants, getDates, getDirections, getEvents, getSwipeEventId
+import backend.storage_access_layer.accessfunctions as db
+
+participants = db.getParticipants()
+dates = db.getDates(participants[0])
+directions = db.getDirections(participants[0], dates[0])
+events = db.getEvents(participants[0], dates[0], directions[0])
+both_events = db.getBothDirectionEvents(participants[0], dates[0])
+
+swipe_event_id = db.getSwipeEventId(
+    participants[0],
+    dates[0],
+    events[0],
+    directions[0],
 )
 
-with Session(engine) as session:
-    participants = getParticipants(session)
-    dates = getDates(session, participants[0])
-    directions = getDirections(session, participants[0], dates[0])
-    events = getEvents(session, participants[0], dates[0])
+print("Swipe Event ID:", swipe_event_id)
+print("Both Direction Events:", both_events)
 
-    swipe_event_id = getSwipeEventId(
-        session,
-        participant=participants[0],
-        date=dates[0],
-        event=events[0],
-        direction=directions[0],
-    )
-
-    print("Swipe Event ID:", swipe_event_id)
+---

--- a/backend/storage_access_layer/accessfunctions.py
+++ b/backend/storage_access_layer/accessfunctions.py
@@ -2,30 +2,41 @@ from sqlalchemy import select
 from sqlalchemy import distinct
 from sqlalchemy.orm import Session
 from .db import SwipeEvent
+from .db import get_session
 
 import datetime
 #function which retreives participants list from the database
-def getParticipants(session: Session) -> list[int]:
-    query = select(distinct(SwipeEvent.participant)).order_by(SwipeEvent.participant)
-    return session.scalars(query).all()
+def getParticipants() -> list[int]:
+    with get_session() as session:
+        query = select(distinct(SwipeEvent.participant)).order_by(SwipeEvent.participant)
+        return session.scalars(query).all()
 
 #function which retrieves dates based on input participant
-def getDates(session: Session, participant: int) -> list[datetime.date]:
-    query = select(distinct(SwipeEvent.date)).where(SwipeEvent.participant == participant).order_by(SwipeEvent.date)
-    return session.scalars(query).all()
+def getDates(participant: int) -> list[datetime.date]:
+    with get_session() as session:
+        query = select(distinct(SwipeEvent.date)).where(SwipeEvent.participant == participant).order_by(SwipeEvent.date)
+        return session.scalars(query).all()
 
 #function which retrieves directions based on participant and date. directions can only be "in" or "out"
-def getDirections(session: Session, participant: int, date: datetime.date) -> list[str]:
-    query = select(distinct(SwipeEvent.direction)).where(SwipeEvent.participant == participant, SwipeEvent.date == date).order_by(SwipeEvent.direction)
-    return session.scalars(query).all()
+def getDirections(participant: int, date: datetime.date) -> list[str]:
+    with get_session() as session:
+        query = select(distinct(SwipeEvent.direction)).where(SwipeEvent.participant == participant, SwipeEvent.date == date).order_by(SwipeEvent.direction)
+        return session.scalars(query).all()
 
 #function which retrieves directions based on participant, date and direction
-def getEvents(session: Session, participant: int, date: datetime.date, direction: str) -> list[int]:
-     query = select(distinct(SwipeEvent.event_number)).where(SwipeEvent.participant == participant, SwipeEvent.date == date, SwipeEvent.direction == direction).order_by(SwipeEvent.event_number)
-     return session.scalars(query).all()
+def getEvents(participant: int, date: datetime.date, direction: str) -> list[int]:
+     with get_session() as session:
+        query = select(distinct(SwipeEvent.event_number)).where(SwipeEvent.participant == participant, SwipeEvent.date == date, SwipeEvent.direction == direction).order_by(SwipeEvent.event_number)
+        return session.scalars(query).all()
 
 #function which retrieves full event ID based on participant, date, direction and event info. This is the location of the csv and npz format metadata
-def getSwipeEventId(session: Session,participant: int,date: datetime.date,event: int,direction: str,) -> str | None:
-    query = select(SwipeEvent.event_id).where(SwipeEvent.participant == participant,SwipeEvent.date == date,SwipeEvent.event_number == event,SwipeEvent.direction == direction)
-    return session.scalars(query).first()
+def getSwipeEventId(participant: int,date: datetime.date,event: int,direction: str,) -> str | None:
+    with get_session() as session:
+        query = select(SwipeEvent.event_id).where(SwipeEvent.participant == participant,SwipeEvent.date == date,SwipeEvent.event_number == event,SwipeEvent.direction == direction)
+        return session.scalars(query).first()
 
+#helper function that will return a 2 dimensional list storing the events of all directions included for that date. 
+
+def getBothDirectionEvents(participant: int, date: datetime.date) -> list[list[int]]:
+    directions = getDirections(participant, date)
+    return [getEvents(participant, date, direction) for direction in directions]

--- a/backend/storage_access_layer/db.py
+++ b/backend/storage_access_layer/db.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from contextlib import contextmanager
 import datetime
 
 load_dotenv()
@@ -40,15 +42,27 @@ class SwipeEvent(Base):
         server_default=text("CURRENT_TIMESTAMP" if os.environ.get("DATABASE_URL", "").startswith("sqlite") else "now()") #only for pytest to help CI -jon
     )
     
-
-
 dsn = os.environ.get("DATABASE_URL")
-
-#just added this so I could use sql lite to run my pytest -jon
-if dsn:
+if dsn:#just added this so I could use sql lite to run my pytest -jon
     engine = create_engine(dsn)
 else:
     engine = create_engine("sqlite:///:memory:") 
+
+#added a session helper function to limit coupling between layers 
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+@contextmanager
+def get_session():
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 participant = 1
 date = datetime.date(2025, 1, 1)

--- a/tests/backend/test_accessfunctions.py
+++ b/tests/backend/test_accessfunctions.py
@@ -1,13 +1,15 @@
 # tests/test_accessfunctions.py
 import os
-os.environ["DATABASE_URL"] = "sqlite:///:memory:"
-
+# use on-disk sqlite database for testing. avoids shared-memory issues on windows
+os.environ["DATABASE_URL"] = "sqlite:///test_temp.db"
 
 import pytest
 import datetime
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+# import from the backend storage access layer
+from backend.storage_access_layer import db
 from backend.storage_access_layer.db import Base, SwipeEvent
 from backend.storage_access_layer.accessfunctions import (
     getParticipants,
@@ -15,16 +17,22 @@ from backend.storage_access_layer.accessfunctions import (
     getDirections,
     getEvents,
     getSwipeEventId,
+    getBothDirectionEvents,
 )
 
-@pytest.fixture(scope="module")
-def session():
-    #create in memory sql lite. temp database for testing 
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    session = Session(engine)
+@pytest.fixture(scope="module", autouse=True)
+def setup_test_db():
+    # create on-disk sqlite. temp database for testing 
+    test_engine = create_engine("sqlite:///test_temp.db")
 
-    #simple test data, should simulate real swipe event data
+    # rebind backend engine and session maker to shared test engine
+    db.engine = test_engine
+    db.SessionLocal.configure(bind=test_engine)
+
+    # create database schema for testing
+    Base.metadata.create_all(test_engine)
+
+    # simple test data, should simulate real swipe event data
     test_data = [
         SwipeEvent(
             event_id="test_11111_2025-01-01_in_1_complete",
@@ -61,34 +69,49 @@ def session():
         ),
     ]
 
-    session.add_all(test_data)
-    session.commit()
-    #use yield to provide session to tests
-    yield session  
+    # use context manager to populate temp db
+    with Session(test_engine) as session:
+        session.add_all(test_data)
+        session.commit()
 
-    #equivelant to closing things down when the tests are complete
-    session.close()
-    Base.metadata.drop_all(engine)
+    # yield allows setup before tests and teardown after tests
+    yield  
 
-#tests
+    # teardown the test database and dispose of engine resources
+    Base.metadata.drop_all(test_engine)
+    test_engine.dispose()
 
-def test_getParticipants(session):
-    assert sorted(getParticipants(session)) == [11111, 22222, 33333]
+    # remove temp file when done
+    if os.path.exists("test_temp.db"):
+        os.remove("test_temp.db")
 
-def test_getDates(session):
-    assert getDates(session, 11111) == [datetime.date(2025, 1, 1)]
 
-def test_getDirections(session):
-    assert getDirections(session, 22222, datetime.date(2025, 1, 2)) == ["out"]
+# -------------------- TESTS -------------------- #
 
-def test_getEvents(session):
-    assert getEvents(session, 33333, datetime.date(2025, 1, 3), "in") == [3]
+def test_getParticipants():
+    assert sorted(getParticipants()) == [11111, 22222, 33333]
 
-def test_getSwipeEventId(session):
-    result = getSwipeEventId(session, 11111, datetime.date(2025, 1, 1), 1, "in")
+def test_getDates():
+    assert getDates(11111) == [datetime.date(2025, 1, 1)]
+
+def test_getDirections():
+    assert getDirections(22222, datetime.date(2025, 1, 2)) == ["out"]
+
+def test_getEvents():
+    assert getEvents(33333, datetime.date(2025, 1, 3), "in") == [3]
+
+def test_getSwipeEventId():
+    result = getSwipeEventId(11111, datetime.date(2025, 1, 1), 1, "in")
     assert result == "test_11111_2025-01-01_in_1_complete"
 
-def test_getSwipeEventId_nonexistent(session):
-    result = getSwipeEventId(session, 99999, datetime.date(2025, 1, 1), 1, "in")
+def test_getSwipeEventId_nonexistent():
+    result = getSwipeEventId(99999, datetime.date(2025, 1, 1), 1, "in")
     assert result is None
+
+# new function test for getBothDirectionEvents
+def test_getBothDirectionEvents():
+    result = getBothDirectionEvents(22222, datetime.date(2025, 1, 2))
+    # should return a 2D list even if only one direction exists
+    assert isinstance(result, list)
+    assert all(isinstance(inner, list) for inner in result)
 


### PR DESCRIPTION
accessfunctions.py

is a file used to store accessor functions for the backend to interact with the postgres database

test_accessfunctions.py

a pytest file used to run unit tests on the accessfunctions.py

readme.md

a brief readme meant to help other members of the project understand the logical decisions behind any changes made in the storage_access_layer portion of the repo

small syntax changes made to db.py to help facilitate pytest. I essentially adopted accessfunctions.py as a child object of db.py so I could use the swipe event utility